### PR TITLE
Ajustando tamanho de botões do ChatSuggestions

### DIFF
--- a/packages/ui/components/ChatSuggestions.tsx
+++ b/packages/ui/components/ChatSuggestions.tsx
@@ -42,7 +42,7 @@ const ChatSuggestions = ({}: any) => (
     <Stack
       direction={[ "column", "row" ]}
       wrap="wrap"
-      alignContent="flex-start"
+      alignItems="flex-start"
       pt="1rem"
     >
       {suggestions.map(({ text }, index) => (


### PR DESCRIPTION
- Adicionei um` alignItems: flex-start` ao grupo de botões em telas mobile para deixar eles alinhados á esquerda.

Ficou dessa forma: 

![aling-itens](https://github.com/mapadoacolhimento/boas-vindas-chatbot/assets/89156781/9dcefdad-848e-474c-96f5-85b74e3521a8)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205417328301650