### PR TITLE
Corrigir peso de fonte do chat

### DIFF
--- a/packages/ui/app/page.tsx
+++ b/packages/ui/app/page.tsx
@@ -14,10 +14,22 @@ function ChatHeader() {
       align={"center"}
       pl={8}
     >
-      <Center boxSize={7} borderRadius={"base"} bg="#FFDBDB">
-        <ChatIcon boxSize={3.5} aria-label="Icon de mensagem" />
+      <Center 
+        boxSize={7} 
+        borderRadius={"base"} 
+        bg="#FFDBDB"
+      >
+        <ChatIcon 
+          boxSize={3.5} 
+          aria-label="Icon de mensagem" 
+        />
       </Center>
-      <Heading as={"h2"} color="brand.primary" size={"sm"}>
+      <Heading 
+        as={"h2"} 
+        color="brand.primary" 
+        size={"sm"} 
+        fontWeight="700"
+      >
         Fale com a IAna
       </Heading>
     </HStack>

--- a/packages/ui/components/ChatSuggestions.tsx
+++ b/packages/ui/components/ChatSuggestions.tsx
@@ -26,7 +26,7 @@ const ChatSuggestions = ({}: any) => (
     <Text
       display={{ base: "none", sm: "initial" }}
       fontSize="sm"
-      fontWeight="semibold"
+      fontWeight="700"
       color="brand.primary"
     >
       Não sabe como começar? Temos algumas sugestões de conteúdo:
@@ -34,7 +34,7 @@ const ChatSuggestions = ({}: any) => (
     <Text
       display={{ base: "initial", sm: "none" }}
       fontSize="sm"
-      fontWeight="semibold"
+      fontWeight="700"
       color="brand.primary"
     >
       Sugestões de conteúdo:

--- a/packages/ui/components/ChatSuggestions.tsx
+++ b/packages/ui/components/ChatSuggestions.tsx
@@ -50,6 +50,7 @@ const ChatSuggestions = ({}: any) => (
           key={index}
           variant={"option"}
           size={"sm"}
+          fontWeight="400"
         >
           {text}
         </Button>

--- a/packages/ui/theme/index.ts
+++ b/packages/ui/theme/index.ts
@@ -2,7 +2,11 @@ import { extendTheme } from "@chakra-ui/react";
 import { Fugaz_One, Nunito_Sans } from "next/font/google";
 import ButtonCustomization from "./ButtonCustomization";
 
-const nunito = Nunito_Sans({ subsets: ["latin"], weight: ["400", "700"] });
+const nunito = Nunito_Sans({
+  subsets: ["latin"],
+  weight: ["200", "300", "400", "500", "600", "700"],
+  display: "swap"
+});
 const fugazOne = Fugaz_One({ subsets: ["latin"], weight: ["400"] });
 
 const theme = extendTheme({


### PR DESCRIPTION
- Implementei outros pesos de fonte da **Nunito-Sans** no código
- Adicionei `fontWeight = 700` aos textos **(Mobile e Desktop),**  do grupo de botões de sugestões 
- Adicionei `fontWeight = 400` aos botões de sugestões
- Também fiz a correção de indentação desses três pontos do código

Está dessa forma mobile: 

![dessa-forma-mobile](https://github.com/mapadoacolhimento/boas-vindas-chatbot/assets/89156781/9ab5a5ba-423b-486f-8cbd-dc4d3ed59b9c)

Está dessa forma desktop:

![dessa-forma-desk](https://github.com/mapadoacolhimento/boas-vindas-chatbot/assets/89156781/e618b585-2e41-4995-86ee-0f0c0bab5499)




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205417330611653