### PR TITLE
Corrigir o alinhamento do IconChat

### DIFF
--- a/packages/ui/components/ChatLine.tsx
+++ b/packages/ui/components/ChatLine.tsx
@@ -54,7 +54,11 @@ export default function ChatLine({
   const formatteMessage = convertNewLines(content);
 
   return (
-    <VStack spacing={0} align={"flex-start"} justify={"flex-start"}>
+    <VStack 
+      spacing={0} 
+      align={"flex-start"} 
+      justify={"flex-start"}
+    >
       <Box
         bgColor={role === "assistant" ? "chatBackground" : "white"}
         py={"15px"}

--- a/packages/ui/components/ChatLine.tsx
+++ b/packages/ui/components/ChatLine.tsx
@@ -60,7 +60,10 @@ export default function ChatLine({
         py={"15px"}
         px={8}
       >
-        <HStack spacing={"10px"}>
+        <HStack
+          alignItems="flex-start" 
+          spacing={"10px"}
+        >
           {role === "assistant" ? (
             <ChatIcon boxSize={"14px"} />
           ) : (


### PR DESCRIPTION
Adicionei um `flex-start` para que o Icon fique alinhado ao topo. 

Estava dessa forma antes:

![iconChat](https://github.com/mapadoacolhimento/boas-vindas-chatbot/assets/89156781/517efac7-53f7-44b9-b8a2-8f50fd2e78ac)

Como está agora:

![iconchat-jj](https://github.com/mapadoacolhimento/boas-vindas-chatbot/assets/89156781/5809b7fa-92ce-4392-b867-628eaeff0aa5)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205417330611646