### PR TITLE
feat: endpoint para criar o index

### DIFF
--- a/packages/api/app.py
+++ b/packages/api/app.py
@@ -11,7 +11,8 @@ import s3fs
 from llama_index import ServiceContext, set_global_service_context, StorageContext, load_index_from_storage
 from llama_index.prompts import Prompt
 from llama_index.llms import OpenAI
-from constants import IANA_PROMPT
+from functions.constants import IANA_PROMPT
+from functions.create_index import create_index_from_documents
 
 app = Flask(__name__)
 
@@ -65,3 +66,8 @@ def hello_from_root():
 @app.errorhandler(404)
 def resource_not_found(e):
     return make_response(jsonify(error='Not found!'), 404)
+
+@app.route("/create-index")
+def create_index():
+    create_index_from_documents()
+    return "Index created successfully", 200

--- a/packages/api/functions/common_functions.py
+++ b/packages/api/functions/common_functions.py
@@ -1,0 +1,24 @@
+import openai
+import s3fs
+import os
+
+from llama_index import ServiceContext
+from llama_index.llms import OpenAI
+
+def set_open_ai_api_key():
+    openai.api_key = os.environ["OPENAI_API_KEY"]
+
+def create_service_context():
+    #Change this to GPT-4 once we have access
+    llm = OpenAI(temperature=0.1, model="gpt-3.5-turbo")
+    service_context = ServiceContext.from_defaults(llm=llm)
+    return service_context
+
+def create_s3_client():
+    s3 = s3fs.S3FileSystem(
+        key=os.environ["AWS_ROOT_ACCESS_KEY_ID"],
+        secret=os.environ["AWS_ROOT_SECRET_ACCESS_KEY"],
+        endpoint_url="https://s3.sa-east-1.amazonaws.com",
+    )
+    return s3
+    

--- a/packages/api/functions/constants.py
+++ b/packages/api/functions/constants.py
@@ -16,3 +16,5 @@ IANA_PROMPT = (
     "🩺 Unidades básicas de saúde (UBS): Os impactos na saúde física e psicológica nas mulheres que sofrem violência podem se apresentar de diferentes formas, e as UBS (ou postinhos) oferecem acolhimento multidisciplinar (médica, enfermeira, psicóloga, terapeuta ocupacional, assistente social), integral e acompanhamento a longo prazo para construir caminhos possíveis, avaliação de risco, plano de segurança e encaminhamento para outros serviços da saúde e/ou jurídicos. Nos casos de violência sexual, realizam a contracepção de emergência, prevenção das doenças sexualmente transmissíveis (DST) - incluindo o HIV; assim como o acolhimento, orientação e encaminhamento para casos de abortamento legal.\n"
     "Esses serviços são fundamentais para proteger, apoiar e empoderar as mulheres que enfrentam a violência de gênero. Lembrando que a disponibilidade pode variar em diferentes regiões. 💪🌟'\n"
 )
+
+INDEX_ID = "doc_summary_index"

--- a/packages/api/functions/create_index.py
+++ b/packages/api/functions/create_index.py
@@ -1,0 +1,44 @@
+import os
+
+from llama_index import download_loader
+from llama_index.indices.document_summary import DocumentSummaryIndex
+
+from .common_functions import set_open_ai_api_key, create_service_context, create_s3_client
+from .constants import INDEX_ID
+
+
+def read_s3_documents():
+  S3Reader = download_loader("S3Reader")
+
+  loader = S3Reader(
+    bucket=os.environ["AWS_S3_BUCKET_NAME"],
+    key='documents/',
+    aws_access_id=os.environ["AWS_ROOT_ACCESS_KEY_ID"],
+    aws_access_secret=os.environ["AWS_ROOT_SECRET_ACCESS_KEY"],
+    s3_endpoint_url="https://s3.sa-east-1.amazonaws.com")
+
+  documents = loader.load_data()
+
+  return documents
+
+
+def create_doc_summary_index(documents, service_context):
+  doc_summary_index = DocumentSummaryIndex.from_documents(
+    documents=documents, 
+    service_context=service_context)
+  return doc_summary_index
+
+def save_index_to_s3(doc_summary_index):
+  s3 = create_s3_client()
+  path = os.environ["AWS_S3_BUCKET_NAME"] + '/index'
+  doc_summary_index.set_index_id(INDEX_ID)
+  doc_summary_index.storage_context.persist(path, fs=s3)
+
+
+def create_index_from_documents():
+  set_open_ai_api_key()
+  service_context = create_service_context()
+  
+  documents = read_s3_documents()
+  doc_summary_index = create_doc_summary_index(documents, service_context)
+  save_index_to_s3(doc_summary_index)


### PR DESCRIPTION
Esse PR cria o endpoint `/create-index`, que:
- lê os documentos da capacitação, que ficam na pasta `/documents` no s3;
- cria um index a partir desses documentos
- salva esse index na pasta `/index` do s3

A ideia é que esse endpoint seja usado toda vez que houver uma atualização nos documentos da capacitação.