### PR TITLE
Adicionando AutoRisize ao input mobile

### DIFF
--- a/packages/ui/components/InputMessage.tsx
+++ b/packages/ui/components/InputMessage.tsx
@@ -85,7 +85,8 @@ const InputMessage = ({
         />
 
         <AutoResizeTextarea
-          display={{ base: "initial", md: "none" }}
+          display={{ base:"initial", md: "none" }}
+          maxRows={3}
           _hover={{
             borderWidth: "1px",
             borderStyle: "solid",
@@ -128,8 +129,10 @@ const InputMessage = ({
           pr={35}
         />
         <InputRightElement
-          display={{ base: "initial", md: "none" }}
+          display={{ base: "flex", md: "none" }}
+          p="5px"
           h="100%"
+          
         >
           <IconButton
             size={"xs"}

--- a/packages/ui/components/InputMessage.tsx
+++ b/packages/ui/components/InputMessage.tsx
@@ -6,8 +6,26 @@ import {
   InputGroup,
   InputRightElement,
   useMediaQuery,
+  Textarea,
+  forwardRef
 } from "@chakra-ui/react";
+import ResizeTextarea from "react-textarea-autosize";
+import { SearchIcon } from "@chakra-ui/icons";
+
 import SendMessageIcon from "./SendMessageIcon";
+
+export const AutoResizeTextarea = forwardRef((props, ref) => (
+  <Textarea
+    minH="unset"
+    overflow="hidden"
+    w="100%"
+    resize="none"
+    ref={ref}
+    minRows={3}
+    as={ResizeTextarea}
+    {...props}
+  />
+));
 
 const InputMessage = ({
   input,
@@ -23,6 +41,74 @@ const InputMessage = ({
     ? "Envie sua pergunta ou dúvida e a IAna vai te ajudar"
     : "Envie sua pergunta ou dúvida";
 
+  return (
+    <Box px={6} w={"full"}>
+      <InputGroup gap={{ base: 0, md: 4 }}>
+        <AutoResizeTextarea
+          _hover={{
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderColor: "brand.primaryMedium",
+            boxShadow: "0px 3px 10px 0px #0000001a",
+          }}
+          _focus={{
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderColor: "brand.primaryMedium",
+            boxShadow: "0px 3px 10px 0px #0000001a",
+          }}
+          placeholder={placeholder}
+          _placeholder={{
+            opacity: 1,
+            color: "placeholder",
+            size: "md",
+            fontsize: "13px",
+            fontWeight: "400",
+          }}
+          borderRadius="md"
+          border="1px solid"
+          borderColor="brand.lightGray"
+          aria-label="Campo de envio de mensagem"
+          required
+          value={input}
+          onKeyDown={(event: React.KeyboardEvent<HTMLInputElement>) => {
+            if (event.key === "Enter") {
+              sendMessage(input);
+              setInput("");
+            }
+          }}
+          onChange={(event: React.ChangeEvent<HTMLInputElement>) => {
+            setInput(event.target.value);
+          }}
+
+          variant="outline"
+          size="xs"
+          minRows={1}
+          pr={35}
+        />
+        <InputRightElement
+          h="100%"
+        >
+          <IconButton
+            size={"xs"}
+            color={"white"}
+            icon={<SendMessageIcon boxSize={4} />}
+            aria-label="Enviar mensagem"
+            type="submit"
+            onClick={() => {
+              sendMessage(input);
+              setInput("");
+            }}
+            isDisabled={input === ""}
+            _disabled={{
+              bgColor: "transparent",
+              color: "brand.primaryGray",
+            }}
+          />
+        </InputRightElement>
+      </InputGroup>
+    </Box>
+  );
   return (
     <Box px={6} w={"full"}>
       <InputGroup gap={{ base: 0, md: 4 }}>

--- a/packages/ui/components/InputMessage.tsx
+++ b/packages/ui/components/InputMessage.tsx
@@ -44,7 +44,48 @@ const InputMessage = ({
   return (
     <Box px={6} w={"full"}>
       <InputGroup gap={{ base: 0, md: 4 }}>
+        <Input
+          display={{ base: "none", md: "initial" }}
+          _hover={{
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderColor: "brand.primaryMedium",
+            boxShadow: "0px 3px 10px 0px #0000001a",
+          }}
+          _focus={{
+            borderWidth: "1px",
+            borderStyle: "solid",
+            borderColor: "brand.primaryMedium",
+            boxShadow: "0px 3px 10px 0px #0000001a",
+          }}
+          placeholder={placeholder}
+          _placeholder={{
+            opacity: 1,
+            color: "placeholder",
+            size: "md",
+            fontsize: "13px",
+            fontWeight: "400",
+          }}
+          borderRadius="md"
+          border="1px solid"
+          borderColor="brand.lightGray"
+          type="text"
+          aria-label="Campo de envio de mensagem"
+          required
+          value={input}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              sendMessage(input);
+              setInput("");
+            }
+          }}
+          onChange={(e) => {
+            setInput(e.target.value);
+          }}
+        />
+
         <AutoResizeTextarea
+          display={{ base: "initial", md: "none" }}
           _hover={{
             borderWidth: "1px",
             borderStyle: "solid",
@@ -87,71 +128,9 @@ const InputMessage = ({
           pr={35}
         />
         <InputRightElement
+          display={{ base: "initial", md: "none" }}
           h="100%"
         >
-          <IconButton
-            size={"xs"}
-            color={"white"}
-            icon={<SendMessageIcon boxSize={4} />}
-            aria-label="Enviar mensagem"
-            type="submit"
-            onClick={() => {
-              sendMessage(input);
-              setInput("");
-            }}
-            isDisabled={input === ""}
-            _disabled={{
-              bgColor: "transparent",
-              color: "brand.primaryGray",
-            }}
-          />
-        </InputRightElement>
-      </InputGroup>
-    </Box>
-  );
-  return (
-    <Box px={6} w={"full"}>
-      <InputGroup gap={{ base: 0, md: 4 }}>
-        <Input
-          _hover={{
-            borderWidth: "1px",
-            borderStyle: "solid",
-            borderColor: "brand.primaryMedium",
-            boxShadow: "0px 3px 10px 0px #0000001a",
-          }}
-          _focus={{
-            borderWidth: "1px",
-            borderStyle: "solid",
-            borderColor: "brand.primaryMedium",
-            boxShadow: "0px 3px 10px 0px #0000001a",
-          }}
-          placeholder={placeholder}
-          _placeholder={{
-            opacity: 1,
-            color: "placeholder",
-            size: "md",
-            fontsize: "13px",
-            fontWeight: "400",
-          }}
-          borderRadius="md"
-          border="1px solid"
-          borderColor="brand.lightGray"
-          type="text"
-          aria-label="Campo de envio de mensagem"
-          required
-          value={input}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              sendMessage(input);
-              setInput("");
-            }
-          }}
-          onChange={(e) => {
-            setInput(e.target.value);
-          }}
-        />
-
-        <InputRightElement display={{ base: "flex", md: "none" }}>
           <IconButton
             size={"xs"}
             color={"white"}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -27,6 +27,7 @@
     "react": "18.2.0",
     "react-cookie": "^4.1.1",
     "react-dom": "18.2.0",
+    "react-textarea-autosize": "^8.5.3",
     "typescript": "5.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fiz a implementação do `AutoResizeTextarea` no grupo de input mobile.
- Implementei o` maxRows` para limitar a quebra de linha
-  Adicionei a responsividade ao botão mobile que está dentro do input

[Assista o que está pronto aqui](https://www.loom.com/share/c9b344f14a3048a29c2d59a572529946?sid=f2f2acb8-ef7d-49d4-912f-500d34f4044d)

Problemas pendentes:

- É preciso aumentar o texto do placeholder mobile
- Existe problema de scroll. Tem que testar se o input mobile escrolla no celular
- Testar o Enter do input mobile no celular, pois no computador, quando clico no Enter, ele envia a mensagem mas deixa espaço na caixa do input
- Adicionar espaço entre o placeholder e botão
